### PR TITLE
Formatting: clean up whitespace in Socket/ServerSocket model classes …

### DIFF
--- a/src/classes/modules/java.base/java/net/ServerSocket.java
+++ b/src/classes/modules/java.base/java/net/ServerSocket.java
@@ -4,10 +4,11 @@ import java.io.IOException;
 
 /**
  * Model class for java.net.ServerSocket
- * 
+ *
  * @author Nastaran Shafiei
  */
 public class ServerSocket implements java.io.Closeable {
+
 
   /**
    * The implementation of this Socket.
@@ -26,7 +27,7 @@ public class ServerSocket implements java.io.Closeable {
   /**
    * This creates a 'bound' socket which is ready for ServerSocket.accept() to
    * be called.
-   * 
+   *
    * @param port
    *          the local port on which this socket listen for connections
    */
@@ -49,9 +50,8 @@ public class ServerSocket implements java.io.Closeable {
    * ServerSocket.bind() before ServerSocket.accept() is invoked
    */
   public ServerSocket () throws IOException {
-
   }
-  
+
   private Object lock = new Object();
 
   private Socket acceptedSocket;
@@ -67,9 +67,9 @@ public class ServerSocket implements java.io.Closeable {
   public Socket accept () throws IOException {
     if (isClosed()) {
       throw new SocketException("Socket is closed");
-    } 
+    }
     // TODO: check for the "unbound" state
-    
+
     // The IO buffers of this socket are shared natively with the client socket
     // at the other end
     acceptedSocket = new Socket();
@@ -87,12 +87,12 @@ public class ServerSocket implements java.io.Closeable {
   // TODO: Throws IOException, if an I/O error occurs when closing the socket
   @Override
   public native synchronized void close ();
-  
+
   private int timeout;
   public void setSoTimeout(int timeout) {
     this.timeout = timeout;
   }
-  
+
   @Override
   protected void finalize() throws Throwable{
     close();

--- a/src/classes/modules/java.base/java/net/Socket.java
+++ b/src/classes/modules/java.base/java/net/Socket.java
@@ -4,28 +4,30 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-/** 
+/**
  * Model class for java.net.Socket
- * 
+ *
  * @author Nastaran Shafiei
  */
 public class Socket implements java.io.Closeable {
 
+
+
   private SocketInputStream input = null;
   private SocketOutputStream output = null;
-  
+
   /**
-   *  This is used to make JPF account for connection objects when state matching. This 
-   *  keep the hash value of this socket connection object, and it is updated upon any 
-   *  internal change to the connection
+   * This is used to make JPF account for connection objects when state matching.
+   * Keep the hash value of this socket connection object, and it is updated upon any
+   * internal change to the connection
    */
   private int hash;
-  
+
   /**
    * The implementation of this Socket.
    */
-  SocketImpl impl; 
-  
+  SocketImpl impl;
+
   /**
    * Various states of this socket.
    */
@@ -65,13 +67,15 @@ public class Socket implements java.io.Closeable {
   }
 
   private native void connect(String host, int port) throws IOException;
+
   public int getHash() {
     return this.hash;
   }
+
   public void connect(SocketAddress endpoint) throws IOException {
     connect(endpoint, 0);
   }
-  
+
   public void connect(SocketAddress endpoint, int timeout) throws IOException {
     // TODO: for timeout, look at wait() implementation
     String host = ((InetSocketAddress)endpoint).getHostName();
@@ -89,10 +93,10 @@ public class Socket implements java.io.Closeable {
     } else if (!isConnected()) {
       throw new SocketException("Socket is not connected");
     }
-    
+
     assert(!isClosed());
     assert(isConnected());
-    
+
     return input;
   }
 
@@ -102,36 +106,36 @@ public class Socket implements java.io.Closeable {
     } else if (!isConnected()) {
       throw new SocketException("Socket is not connected");
     }
-    
+
     assert(!isClosed());
     assert(isConnected());
-    
+
     return output;
   }
-  
+
   /**
    * Returns the closed state of the socket.
    */
   public boolean isClosed() {
     return this.closed;
   }
-  
+
   /**
    * Returns the connection state of the socket.
    */
   public native boolean isConnected();
-  
-  // TODO: Any thread currently blocked in an I/O operation upon this socket 
+
+  // TODO: Any thread currently blocked in an I/O operation upon this socket
   //       will throw a SocketException.
   // TODO: Throws IOException, if an I/O error occurs when closing the socket
   @Override
   public native void close() throws IOException;
-  
+
   private int timeout;
   public void setSoTimeout(int timeout) {
     this.timeout = timeout;
   }
-  
+
   @Override
   protected void finalize() throws Throwable{
     close();

--- a/src/tests/net/nas/SocketTest.java
+++ b/src/tests/net/nas/SocketTest.java
@@ -18,43 +18,43 @@ import gov.nasa.jpf.util.test.TestMultiProcessJPF;
 
 public class SocketTest extends TestNasJPF {
   String[] args = { "+search.multiple_errors = true",
-                    "+vm.process_finalizers = true",
-                    "+vm.nas.initiating_target = 0"
-                  };
-  
+          "+vm.process_finalizers = true",
+          "+vm.nas.initiating_target = 0"
+  };
+
   int port = 1024;
   final String HOST = "localhost";
-  
+
   @Test
   public void testEstablishingConnection() throws IOException {
     if (mpVerifyNoPropertyViolation(2, args)) {
-      
+
       switch(getProcessId()) {
-      case 0:
-        ServerSocket serverSocket = new ServerSocket(port);
-        serverSocket.setSoTimeout(10);
-        Socket sock1 = null;
-        try {
-          sock1 = serverSocket.accept();
-        } catch(SocketTimeoutException e) {
-          // gets here if no request is coming after a certain amount of time
-          assertNull(sock1);
-        }
-        break;
-        
-      case 1:
-        Socket sock2;
-        try {
-          sock2 = new Socket(HOST, port);
-          assertTrue(sock2.isConnected());
-        } catch(IOException e) {
-          // gets here if there was no server accepting the connection request
-        }
-        break;
+        case 0:
+          ServerSocket serverSocket = new ServerSocket(port);
+          serverSocket.setSoTimeout(10);
+          Socket sock1 = null;
+          try {
+            sock1 = serverSocket.accept();
+          } catch(SocketTimeoutException e) {
+            // gets here if no request is coming after a certain amount of time
+            assertNull(sock1);
+          }
+          break;
+
+        case 1:
+          Socket sock2;
+          try {
+            sock2 = new Socket(HOST, port);
+            assertTrue(sock2.isConnected());
+          } catch(IOException e) {
+            // gets here if there was no server accepting the connection request
+          }
+          break;
       }
     }
   }
-  
+
   /**
    * Blocking accept with timeout throws SocketTimeoutException
    */
@@ -80,82 +80,82 @@ public class SocketTest extends TestNasJPF {
     }
   }
 
-  
+
   @Test
   public void testHash() throws Exception {
     if (mpVerifyNoPropertyViolation(2, args)) {
-     
+
       switch(getProcessId()) {
-      case 0:
-        ServerSocket serverSocket = new ServerSocket(port);
-        Socket sock1 = serverSocket.accept();
-        
-        int h1 = getHash(sock1);
-        assertTrue(h1!=0);
-        
-        OutputStream socketOutput = sock1.getOutputStream();
-        
-        try {
-          socketOutput.write(10);
-          int h2 = getHash(sock1);
-          assertTrue(h1!=h2);
-        } catch(SocketException e) {
-          // attempting to write on a close connection
-        }
-        
-        break;
-      case 1:
-        Socket sock2;
-        try {
-          sock2 = new Socket(HOST, port);
-          
-          
-        } catch(IOException e) {
-          // gets here if there was no server accepting the connection request
-          System.out.println("never stablished!!");
-        }
-        break;
+        case 0:
+          ServerSocket serverSocket = new ServerSocket(port);
+          Socket sock1 = serverSocket.accept();
+
+          int h1 = getHash(sock1);
+          assertTrue(h1!=0);
+
+          OutputStream socketOutput = sock1.getOutputStream();
+
+          try {
+            socketOutput.write(10);
+            int h2 = getHash(sock1);
+            assertTrue(h1!=h2);
+          } catch(SocketException e) {
+            // attempting to write on a close connection
+          }
+
+          break;
+        case 1:
+          Socket sock2;
+          try {
+            sock2 = new Socket(HOST, port);
+
+
+          } catch(IOException e) {
+            // gets here if there was no server accepting the connection request
+            System.out.println("never stablished!!");
+          }
+          break;
       }
     }
   }
-  
+
   @Test
   public void testTimedoutRead() throws IOException {
     if (mpVerifyNoPropertyViolation(2, args)) {
-      
+
       switch(getProcessId()) {
-      case 0:
-        ServerSocket serverSocket = new ServerSocket(port);
-        Socket sock1 = serverSocket.accept();
-        assertTrue(sock1.isConnected());
-        break;
-        
-      case 1:
-        Socket sock2 = null;
-        try {
-          sock2 = new Socket(HOST, port);
-          sock2.setSoTimeout(10);
-          assertTrue(sock2.isConnected());
-        } catch(IOException e) {
-          // gets here if there was no server accepting the connection request
-          return;
-        }
-        
-        try {
-          InputStream in = sock2.getInputStream();
-          in.read();
-          //assertTrue(isOtherEndClosed());
-        } catch(SocketTimeoutException e) {
-          return;
-        } catch(SocketException e) {
-          return;
-        }
-        
-        break;
+        case 0:
+          ServerSocket serverSocket = new ServerSocket(port);
+          Socket sock1 = serverSocket.accept();
+          assertTrue(sock1.isConnected());
+          break;
+
+        case 1:
+          Socket sock2 = null;
+          try {
+            sock2 = new Socket(HOST, port);
+            sock2.setSoTimeout(10);
+            assertTrue(sock2.isConnected());
+          } catch(IOException e) {
+            // gets here if there was no server accepting the connection request
+            return;
+          }
+
+          try {
+            InputStream in = sock2.getInputStream();
+            in.read();
+            //assertTrue(isOtherEndClosed());
+          } catch(SocketTimeoutException e) {
+            return;
+          } catch(SocketException e) {
+            return;
+          }
+
+          break;
       }
     }
   }
-  
+
   static class FinalizeServer {
     @Override
     protected void finalize() throws Throwable {
@@ -164,8 +164,8 @@ public class SocketTest extends TestNasJPF {
       System.out.println("DONE!");
     }
   }
-  
-  // This is testing finalizer threads. It should belong to jpf-core, but I add it here 
+
+  // This is testing finalizer threads. It should belong to jpf-core, but I add it here
   // since it needs support for ServerSocket.accept().
   // here we make sure that MultiProcessVM does not ignore deadlocks in finalizers.
   @Test
@@ -174,4 +174,5 @@ public class SocketTest extends TestNasJPF {
       new FinalizeServer();
     }
   }
+
 }


### PR DESCRIPTION
Part 2 of 4 splitting @Mahmoud-Khawaja's model-classes-fix (#10) into focused PRs, per @cyrille-artho's review feedback.

## Scope: formatting only

- Normalize whitespace and blank lines
- Remove trailing whitespace
- Restore consistent file endings

## Verification

`git diff --ignore-all-space --ignore-blank-lines` against `java-11`