### PR TITLE
Cleanup: remove debug print statements

### DIFF
--- a/src/peers/nas/java/net/JPF_java_net_PlainSocketImpl.java
+++ b/src/peers/nas/java/net/JPF_java_net_PlainSocketImpl.java
@@ -16,19 +16,16 @@ public class JPF_java_net_PlainSocketImpl extends NativePeer {
     private static Map<Integer, Integer> socketTimeouts = new HashMap<>();
 
     static {
-        System.out.println("JPF_java_net_PlainSocketImpl loaded");
     }
 
     @MJI
     public static void $clinit____V(MJIEnv env, int clsObjRef) {
-        System.out.println("PlainSocketImpl static initialization intercepted");
     }
 
 
 
     @MJI
     public static void socketCreate__Z__V(MJIEnv env, int objRef, boolean stream) {
-        System.out.println("PlainSocketImpl.socketCreate() intercepted - stream: " + stream);
 
         // Minimal initialization for test compatibility
         try {
@@ -42,14 +39,12 @@ public class JPF_java_net_PlainSocketImpl extends NativePeer {
             env.setBooleanField(objRef, "stream", stream);
         } catch (Exception e) {
             // If field setting fails, continue - Java 11 compatibility maintained
-            System.out.println("socketCreate: field setting failed, using minimal mode");
         }
     }
 
     @MJI
     public static void socketConnect__Ljava_net_InetAddress_2II__V(MJIEnv env, int objRef,
                                                                    int addressRef, int port, int timeout) {
-        System.out.println("PlainSocketImpl.socketConnect() intercepted");
 
         // Store timeout if provided
         if (timeout > 0) {
@@ -67,7 +62,6 @@ public class JPF_java_net_PlainSocketImpl extends NativePeer {
     @MJI
     public static void socketBind__Ljava_net_InetAddress_2I__V(MJIEnv env, int objRef,
                                                                int addressRef, int port) {
-        System.out.println("PlainSocketImpl.socketBind() intercepted - port: " + port);
 
         // Minimal state setting for test compatibility
         try {
@@ -80,14 +74,12 @@ public class JPF_java_net_PlainSocketImpl extends NativePeer {
 
     @MJI
     public static void socketListen__I__V(MJIEnv env, int objRef, int backlog) {
-        System.out.println("PlainSocketImpl.socketListen() intercepted");
     }
 
     @MJI
     public static void socketAccept__Ljava_net_SocketImpl_2__V(MJIEnv env,
                                                                int serverImplRef,
                                                                int clientImplRef) {
-        System.out.println("PlainSocketImpl.socketAccept() intercepted");
 
         // Set client socket as connected for test compatibility
         if (clientImplRef != MJIEnv.NULL) {
@@ -101,7 +93,6 @@ public class JPF_java_net_PlainSocketImpl extends NativePeer {
 
     @MJI
     public static void socketClose0__Z__V(MJIEnv env, int objRef, boolean useDeferredClose) {
-        System.out.println("PlainSocketImpl.socketClose0() intercepted");
 
         // Clean up timeout tracking
         socketTimeouts.remove(objRef);
@@ -118,14 +109,12 @@ public class JPF_java_net_PlainSocketImpl extends NativePeer {
     @MJI
     public static void socketSetOption__IZLjava_lang_Object_2__V(MJIEnv env, int objRef,
                                                                  int opt, boolean on, int valRef) {
-        System.out.println("PlainSocketImpl.socketSetOption() intercepted - option: " + opt);
 
         // Handle SO_TIMEOUT (0x1006) for test compatibility
         if (opt == 0x1006 && valRef != MJIEnv.NULL) {
             try {
                 int timeout = env.getIntField(valRef, "value");
                 socketTimeouts.put(objRef, timeout);
-                System.out.println("Set socket timeout: " + timeout + "ms");
             } catch (Exception e) {
             }
         }

--- a/src/peers/nas/java/net/JPF_java_net_Socket.java
+++ b/src/peers/nas/java/net/JPF_java_net_Socket.java
@@ -57,7 +57,6 @@ public class JPF_java_net_Socket extends NativePeer {
       env.setReferenceField(socketRef, "lock", lock);
 
     }  catch (Exception e) {
-      System.out.println("Socket initialization: using minimal mode with fallback hash storage");
       synchronized (JPF_java_net_Socket.class) {
         fallbackHashes.put(socketRef, hashCounter++);
       }
@@ -328,7 +327,6 @@ public class JPF_java_net_Socket extends NativePeer {
 
       return inputStreamRef;
     } catch (Exception e) {
-      System.out.println("Failed to create SocketInputStream: " + e.getMessage());
       return MJIEnv.NULL;
     }
   }
@@ -451,7 +449,6 @@ public class JPF_java_net_Socket extends NativePeer {
       }
 
       env.setIntField(socketRef, "hash", newHash);
-      System.out.println("Socket hash updated: " + currentHash + " -> " + newHash + " (type: " + type + ", data: " + data + ")");
     } catch (Exception e) {
       // Use fallback storage
       int currentHash = fallbackHashes.getOrDefault(socketRef, 0);
@@ -469,7 +466,6 @@ public class JPF_java_net_Socket extends NativePeer {
       }
 
       fallbackHashes.put(socketRef, newHash);
-      System.out.println("Fallback hash updated: " + currentHash + " -> " + newHash + " (type: " + type + ", data: " + data + ")");
     }
   }
 
@@ -508,18 +504,15 @@ public class JPF_java_net_Socket extends NativePeer {
       int currentHash = env.getIntField(socketRef, "hash");
       int newHash = currentHash ^ data;
       env.setIntField(socketRef, "hash", newHash);
-      System.out.println("Socket hash updated for data write: " + currentHash + " -> " + newHash + " (data: " + data + ")");
     } catch (Exception e) {
       // Use fallback storage
       int currentHash = fallbackHashes.getOrDefault(socketRef, 0);
       int newHash = currentHash ^ data;
       fallbackHashes.put(socketRef, newHash);
-      System.out.println("Fallback hash updated for data write: " + currentHash + " -> " + newHash + " (data: " + data + ")");
 
       //  to sync back to field periodically
       try {
         env.setIntField(socketRef, "hash", newHash);
-        System.out.println("DEBUG: Successfully synced fallback hash to socket field");
       } catch (Exception syncEx) {
       }
     }

--- a/src/peers/nas/java/net/JPF_java_net_SocketInputStream.java
+++ b/src/peers/nas/java/net/JPF_java_net_SocketInputStream.java
@@ -322,14 +322,4 @@ public class JPF_java_net_SocketInputStream extends NativePeer {
     
     return Scheduler.EMPTY;
   }
-
-  protected static void printWriter(Connection conn, int endpoint) {
-    String result;
-    if(conn.isClientEndSocket(endpoint)) {
-      result = "Client Writing";
-    } else {
-      result = "Server Writing";
-    }
-    System.out.println(result);
-  }
 }

--- a/src/peers/nas/java/net/JPF_java_net_SocketOutputStream.java
+++ b/src/peers/nas/java/net/JPF_java_net_SocketOutputStream.java
@@ -17,12 +17,10 @@ public class JPF_java_net_SocketOutputStream extends NativePeer {
 
   @MJI
   public void write__I__V (MJIEnv env, int objRef, int value) {
-    System.out.println("DEBUG: SocketOutputStream.write() called with value=" + value);
 
     int socketRef = env.getElementInfo(objRef).getReferenceField("socket");
     Connection conn = connections.getConnection(socketRef);
 
-    System.out.println("DEBUG: socketRef=" + socketRef + ", conn=" + conn);
 
     ThreadInfo ti = env.getThreadInfo();
     if(ti.isFirstStepInsn()) { // re-execution
@@ -40,21 +38,17 @@ public class JPF_java_net_SocketOutputStream extends NativePeer {
     } else {
       // **KEY CHANGE: ALWAYS update hash first, regardless of connection status**
       updateSocketHash(env, socketRef, value);
-      System.out.println("DEBUG: Hash update completed for value=" + value);
 
       // Only proceed with actual I/O operations if connection exists
       if(conn == null) {
-        System.out.println("DEBUG: No connection - hash updated but no I/O performed");
         return; // Hash updated successfully, but no network I/O
       }
 
       if(isConnBroken(env, objRef, conn)) {
-        System.out.println("DEBUG: Connection broken, returning after hash update");
         return;
       }
 
       // Proceed with actual network I/O operations
-      System.out.println("DEBUG: Connection exists - proceeding with network I/O");
       int reader = getOtherEnd(conn, socketRef);
 
       if(JPF_java_net_SocketInputStream.isReadBufferEmpty(conn, reader)) {
@@ -62,7 +56,6 @@ public class JPF_java_net_SocketOutputStream extends NativePeer {
       }
 
       writeByte(value, conn, socketRef);
-      System.out.println("DEBUG: Network I/O completed");
     }
   }
 
@@ -80,7 +73,6 @@ public class JPF_java_net_SocketOutputStream extends NativePeer {
   public void write___3BII__V (MJIEnv env, int objRef, int bufferRef, int off, int len) {
     int socketRef = env.getElementInfo(objRef).getReferenceField("socket");
     Connection conn = connections.getConnection(socketRef);
-    System.out.println("DEBUG: SocketOutputStream.write(array) called, len=" + len + ", conn=" + conn);
     ThreadInfo ti = env.getThreadInfo();
     if(ti.isFirstStepInsn()) { // re-execution
       if(Scheduler.failure_injection) {
@@ -99,21 +91,17 @@ public class JPF_java_net_SocketOutputStream extends NativePeer {
       for(int i = off; i < off + len; i++) {
         updateSocketHash(env, socketRef, values[i] & 0xFF);
       }
-      System.out.println("DEBUG: Hash update completed for " + len + " bytes");
 
       // Only proceed with actual I/O operations if connection exists
       if(conn == null) {
-        System.out.println("DEBUG: No connection - hash updated for " + len + " bytes but no I/O performed");
         return; // Hash updated successfully, but no network I/O
       }
 
       if(isConnBroken(env, objRef, conn)) {
-        System.out.println("DEBUG: Connection broken, returning after hash update");
         return;
       }
 
       // Proceed with actual network I/O operations
-      System.out.println("DEBUG: Connection exists - proceeding with network I/O for " + len + " bytes");
       int reader = getOtherEnd(conn, socketRef);
 
       if(JPF_java_net_SocketInputStream.isReadBufferEmpty(conn, reader)) {
@@ -121,7 +109,6 @@ public class JPF_java_net_SocketOutputStream extends NativePeer {
       }
 
       writeByteArray(env, bufferRef, conn, socketRef, off, len);
-      System.out.println("DEBUG: Network I/O completed for " + len + " bytes");
     }
   }
 
@@ -135,7 +122,6 @@ public class JPF_java_net_SocketOutputStream extends NativePeer {
   protected boolean isConnBroken(MJIEnv env, int objRef, Connection conn) {
     // Add null check for connection - DON'T throw exception here
     if (conn == null) {
-      System.out.println("DEBUG: Connection is null - treating as broken");
       // Return true to indicate broken connection, but don't throw exception
       // This avoids JPF serialization issues
       return true;
@@ -238,15 +224,5 @@ public class JPF_java_net_SocketOutputStream extends NativePeer {
     }
     
     return Scheduler.EMPTY;
-  }
-  
-  protected static void printWriter(Connection conn, int endpoint) {
-    String result;
-    if(conn.isClientEndSocket(endpoint)) {
-      result = "Client Writing";
-    } else {
-      result = "Server Writing";
-    }
-    System.out.println(result);
   }
 }

--- a/src/peers/nas/java/net/JPF_jdk_net_ExtendedSocketOptions.java
+++ b/src/peers/nas/java/net/JPF_jdk_net_ExtendedSocketOptions.java
@@ -11,7 +11,6 @@ import gov.nasa.jpf.vm.NativePeer;
 public class JPF_jdk_net_ExtendedSocketOptions extends NativePeer {
 
     static {
-        System.out.println("JPF_jdk_net_ExtendedSocketOptions loaded");
     }
 
     /**
@@ -22,7 +21,6 @@ public class JPF_jdk_net_ExtendedSocketOptions extends NativePeer {
     public static void $clinit____V(MJIEnv env, int clsObjRef) {
         // Mock static initialization - do nothing
         // This prevents the problematic initialization chain
-        System.out.println("ExtendedSocketOptions static initialization intercepted");
     }
 
     @MJI

--- a/src/peers/nas/java/net/JPF_jdk_net_ExtendedSocketOptions_PlatformSocketOptions.java
+++ b/src/peers/nas/java/net/JPF_jdk_net_ExtendedSocketOptions_PlatformSocketOptions.java
@@ -12,7 +12,6 @@ public class JPF_jdk_net_ExtendedSocketOptions_PlatformSocketOptions extends Nat
 
     // Static initialization - called when the peer class is loaded
     static {
-        System.out.println("JPF_jdk_net_ExtendedSocketOptions_PlatformSocketOptions loaded");
     }
 
     /**


### PR DESCRIPTION
Part 3 of 4 splitting @Mahmoud-Khawaja's `model-classes-fix` (#10) into focused PRs, following @cyrille-artho's review feedback.

## Scope

This PR removes temporary debug `System.out.println()` statements and related dead debug-only code from native peer implementations.

## Testing

* Builds successfully.
* Existing `SocketTest` failures (`testTimedoutAccept`, `testHash`, and `testDeadlockForBlockedFinalizer_MulitProcessVM`) are unchanged from the current `java-11` branch.
* No functional changes are intended.