### PR TITLE
fix: remove non-existent build/examples from jpf-nas.classpath

### DIFF
--- a/jpf.properties
+++ b/jpf.properties
@@ -8,7 +8,6 @@ jpf-nas.boot_classpath = ${jpf-nas}/build/jpf-nas-classes.jar
 jpf-nas.classpath = \
   ${jpf-nas}/build/classes/java/main;\
   ${jpf-nas}/build/classes/java/test;\
-  ${jpf-nas}/build/examples;\
   ${jpf-nas}/build/jpf-nas-examples.jar
 
 # Native peers (host JVM) + libs for examples


### PR DESCRIPTION
The examples classes are already included via jpf-nas-examples.jar. The bare build/examples directory path caused unknown classpath warnings.