### PR TITLE
Simplify jpf-nas build configuration and model JAR packaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,21 +117,10 @@ tasks.register('modelJar', Jar) {
     archiveBaseName = 'jpf-nas-classes'
     destinationDirectory = file("${buildDir}")
 
-    // (like jpf-core structure)
-    from("${buildDir}/classes/modules") {
-        into 'modules'
-        include '**/*.class'
-    }
-
-    // include directly under java.base/ for compatibility
+    // Use java.base/ prefix directly (matching jpf-core convention)
     from("${buildDir}/classes/modules") {
         into ''
         include '**/*.class'
-    }
-
-    // Include test helper class if needed
-    from("$buildDir/classes/java/main") {
-        include "nas/util/test/TestNasJPF.class"
     }
 
     manifest {

--- a/jpf.properties
+++ b/jpf.properties
@@ -8,7 +8,6 @@ jpf-nas.boot_classpath = ${jpf-nas}/build/jpf-nas-classes.jar
 jpf-nas.classpath = \
   ${jpf-nas}/build/classes/java/main;\
   ${jpf-nas}/build/classes/java/test;\
-  ${jpf-nas}/build/examples;\
   ${jpf-nas}/build/jpf-nas-examples.jar
 
 # Native peers (host JVM) + libs for examples


### PR DESCRIPTION
## Summary

This PR simplifies the build configuration and model JAR packaging in `jpf-nas`.

## Changes

- Remove the non-existent `build/examples` entry from `jpf-nas.classpath`.
- Package model classes only under the `java.base/` prefix.
- Remove the duplicate packaging under the `modules/` prefix.
- Stop including `TestNasJPF.class` in the model JAR.

## Verification

- Built `jpf-nas-classes.jar` successfully.
- Verified that the generated JAR contains only `java.base/...` model classes.
- Confirmed that duplicate `modules/java.base/...` entries are no longer present.